### PR TITLE
Can connect unencrypted

### DIFF
--- a/apps/example/hexworld_clientcli.cpp
+++ b/apps/example/hexworld_clientcli.cpp
@@ -6,11 +6,13 @@ namespace po = boost::program_options;
 
 int main(int ac, char** av) {
     std::string ServerAddress;
+    bool EncryptedConnection;
     po::options_description desc("Hexagon client options");
     desc.add_options()
             ("help", "help message")
             ("address", po::value<std::string>(&ServerAddress)->default_value("127.0.0.1:8080"),
-             "address to connect to [ip:port]");
+             "address to connect to [ip:port]")
+            ("ssl",po::value<bool>(&EncryptedConnection)->default_value(true), "Connect encrypted");
 
     po::variables_map vm;
     po::store(po::parse_command_line(ac, av, desc), vm);
@@ -25,7 +27,7 @@ int main(int ac, char** av) {
         ServerAddress = vm["address"].as<std::string>();
     }
 
-    HexagonClient hc(ServerAddress);
+    HexagonClient hc(ServerAddress, EncryptedConnection);
     hc.ConnectToServer();
 
     if(hc.GetConnectionState() == hw_conn_state::HEXWORLD_CONNECTION_READY || hc.GetConnectionState() == hw_conn_state::HEXWORLD_CONNECTION_IDLE) {

--- a/include/hexworld/hex_client.h
+++ b/include/hexworld/hex_client.h
@@ -9,7 +9,7 @@ class HexagonClientImpl;
 class HexagonClient {
 public:
     HexagonClient();
-    HexagonClient(std::string server_address);
+    HexagonClient(const std::string server_address, bool ConnectEncrypted);
 
     hw_conn_state ConnectToServer();
 

--- a/lib/hex_client.cpp
+++ b/lib/hex_client.cpp
@@ -5,8 +5,8 @@ HexagonClient::HexagonClient() {
     impl = new HexagonClientImpl();
 }
 
-HexagonClient::HexagonClient(const std::string server_address) {
-    impl = new HexagonClientImpl(server_address);
+HexagonClient::HexagonClient(const std::string server_address, bool ConnectEncrypted) {
+    impl = new HexagonClientImpl(server_address, ConnectEncrypted);
 }
 
 hw_conn_state HexagonClient::ConnectToServer() {

--- a/lib/hex_client_impl.cpp
+++ b/lib/hex_client_impl.cpp
@@ -41,12 +41,15 @@ HexagonClientImpl::HexagonClientImpl() {
     channel = grpc::CreateChannel("127.0.0.1:8080", channel_creds);
 }
 
-HexagonClientImpl::HexagonClientImpl(std::string server_address) {
+HexagonClientImpl::HexagonClientImpl(std::string server_address, bool ConnectEncrypted) {
     auto options = grpc::SslCredentialsOptions();
     options.pem_root_certs = root_certs;
 
-    channel = grpc::CreateChannel(server_address, grpc::SslCredentials(options));
-//    channel = grpc::CreateChannel(server_address, grpc::InsecureChannelCredentials());
+    if (ConnectEncrypted) {
+        channel = grpc::CreateChannel(server_address, grpc::SslCredentials(options));
+    } else {
+        channel = grpc::CreateChannel(server_address, grpc::InsecureChannelCredentials());
+    }
 }
 
 

--- a/lib/hex_client_impl.h
+++ b/lib/hex_client_impl.h
@@ -21,7 +21,7 @@ class HexagonClientImpl {
 public:
     HexagonClientImpl();
 
-    HexagonClientImpl(std::string server_address);
+    HexagonClientImpl(std::string server_address, bool ConnectEncrypted);
 
     hw_conn_state ConnectToServer();
 


### PR DESCRIPTION
Add functionality and command line option to connect unencrypted. This is useful if you run the server locally without SSL.